### PR TITLE
Support for configuration via flogo.json

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"encoding/json"
+
+	"github.com/TIBCOSoftware/bego/common/model"
+	"github.com/TIBCOSoftware/bego/ruleapi"
+)
+
+type RuleSession struct {
+	Rules []*Rule `json:"rules"`
+}
+
+type Rule struct {
+	Name       string
+	Conditions []*Condition
+	ActionFunc model.ActionFunction
+}
+
+type Condition struct {
+	Name        string
+	Identifiers []string
+	Evaluator   model.ConditionEvaluator
+}
+
+func (c *Rule) UnmarshalJSON(d []byte) error {
+
+	ser := &struct {
+		Name         string       `json:"name"`
+		Conditions   []*Condition `json:"conditions"`
+		ActionFuncId string       `json:"actionFunction"`
+	}{}
+
+	if err := json.Unmarshal(d, ser); err != nil {
+		return err
+	}
+
+	c.Name = ser.Name
+	c.Conditions = ser.Conditions
+	c.ActionFunc = GetActionFunction(ser.ActionFuncId)
+
+	return nil
+}
+
+func (c *Condition) UnmarshalJSON(d []byte) error {
+
+	ser := &struct {
+		Name        string   `json:"name"`
+		Identifiers []string `json:"identifiers"`
+		EvaluatorId string   `json:"evaluator"`
+	}{}
+
+	if err := json.Unmarshal(d, ser); err != nil {
+		return err
+	}
+
+	c.Name = ser.Name
+	c.Identifiers = ser.Identifiers
+	c.Evaluator = GetConditionEvaluator(ser.EvaluatorId)
+
+	return nil
+}
+
+//todo this should probably move to ruleapi
+func GetOrCreateRuleSessionFromConfig(name string, config *RuleSession) (model.RuleSession, error) {
+
+	rs, err := ruleapi.GetOrCreateRuleSession(name)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ruleCfg := range config.Rules {
+
+		rule := ruleapi.NewRule(ruleCfg.Name)
+		rule.SetContext("This is a test of context")
+		rule.SetAction(ruleCfg.ActionFunc)
+
+		for _, condCfg := range ruleCfg.Conditions {
+			rule.AddCondition(condCfg.Name, condCfg.Identifiers, condCfg.Evaluator, nil)
+		}
+
+		rs.AddRule(rule)
+	}
+
+	return rs, nil
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/TIBCOSoftware/bego/common/model"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"reflect"
+)
+
+var testSessionJson = `{
+        "rules": [
+          {
+            "name": "n1.name == Bob",
+            "conditions": [
+              {
+                "name": "c1",
+                "identifiers": [ "n1" ],
+                "evaluator": "checkForBob"
+              }
+            ],
+            "actionFunction": "checkForBobAction"
+          },
+          {
+            "name": "n1.name == Bob && n1.name == n2.name",
+            "conditions": [
+              {
+                "name": "c1",
+                "identifiers": [
+                  "n1"
+                ],
+                "evaluator": "checkForBob"
+              },
+              {
+                "name": "c2",
+                "identifiers": [ "n1", "n2" ],
+                "evaluator": "checkSameNamesCondition"
+              }
+            ],
+            "actionFunction": "checkSameNamesAction"
+          }
+        ]
+      }
+`
+
+func TestDeserialize(t *testing.T) {
+
+	RegisterActionFunction("checkForBobAction", checkForBobAction)
+	RegisterActionFunction("checkSameNamesAction", checkSameNamesAction)
+
+	RegisterConditionEvaluator("checkForBob", checkForBob)
+	RegisterConditionEvaluator("checkSameNamesCondition", checkSameNamesCondition)
+
+	sessionCfg := &RuleSession{}
+	err := json.Unmarshal([]byte(testSessionJson), sessionCfg)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, sessionCfg.Rules)
+	assert.Equal(t, 2, len(sessionCfg.Rules))
+
+	r1Cfg := sessionCfg.Rules[0]
+
+	assert.Equal(t, "n1.name == Bob", r1Cfg.Name)
+	assert.NotNil(t, r1Cfg.Conditions)
+	assert.Equal(t, 1, len(r1Cfg.Conditions))
+
+	sf1 := reflect.ValueOf(checkForBobAction)
+	sf2 := reflect.ValueOf(r1Cfg.ActionFunc)
+	assert.Equal(t, sf1.Pointer(), sf2.Pointer())
+
+	r1c1Cfg := r1Cfg.Conditions[0]
+	assert.Equal(t, "c1", r1c1Cfg.Name)
+	assert.NotNil(t, r1c1Cfg.Identifiers)
+	assert.Equal(t, 1, len(r1c1Cfg.Identifiers))
+
+	sf1 = reflect.ValueOf(checkForBob)
+	sf2 = reflect.ValueOf(r1c1Cfg.Evaluator)
+	assert.Equal(t, sf1.Pointer(), sf2.Pointer())
+
+	r2Cfg := sessionCfg.Rules[1]
+
+	assert.Equal(t, "n1.name == Bob && n1.name == n2.name", r2Cfg.Name)
+	assert.NotNil(t, r2Cfg.Conditions)
+	assert.Equal(t, 2, len(r2Cfg.Conditions))
+
+	sf1 = reflect.ValueOf(checkSameNamesAction)
+	sf2 = reflect.ValueOf(r2Cfg.ActionFunc)
+	assert.Equal(t, sf1.Pointer(), sf2.Pointer())
+
+	r2c1Cfg := r2Cfg.Conditions[0]
+	assert.Equal(t, "c1", r2c1Cfg.Name)
+	assert.NotNil(t, r2c1Cfg.Identifiers)
+	assert.Equal(t, 1, len(r2c1Cfg.Identifiers))
+
+	sf1 = reflect.ValueOf(checkForBob)
+	sf2 = reflect.ValueOf(r2c1Cfg.Evaluator)
+	assert.Equal(t, sf1.Pointer(), sf2.Pointer())
+
+	r2c2Cfg := r2Cfg.Conditions[1]
+	assert.Equal(t, "c2", r2c2Cfg.Name)
+	assert.NotNil(t, r2c2Cfg.Identifiers)
+	assert.Equal(t, 2, len(r2c2Cfg.Identifiers))
+
+	sf1 = reflect.ValueOf(checkSameNamesCondition)
+	sf2 = reflect.ValueOf(r2c2Cfg.Evaluator)
+	assert.Equal(t, sf1.Pointer(), sf2.Pointer())
+}
+
+// TEST FUNCTIONS
+
+func checkForBob(ruleName string, condName string, tuples map[model.TupleType]model.Tuple, ctx model.RuleContext) bool {
+	return true
+}
+
+func checkForBobAction(ctx context.Context, rs model.RuleSession, ruleName string, tuples map[model.TupleType]model.Tuple, ruleCtx model.RuleContext) {
+}
+
+func checkSameNamesCondition(ruleName string, condName string, tuples map[model.TupleType]model.Tuple, ctx model.RuleContext) bool {
+	return true
+}
+
+func checkSameNamesAction(ctx context.Context, rs model.RuleSession, ruleName string, tuples map[model.TupleType]model.Tuple, ruleCtx model.RuleContext) {
+}
+
+

--- a/config/manager.go
+++ b/config/manager.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/TIBCOSoftware/flogo-lib/app/resource"
+)
+
+const (
+	uriSchemeRes        = "res://"
+	RESTYPE_RULESESSION = "rulesession"
+)
+
+type ResourceManager struct {
+	configs map[string]*RuleSession
+}
+
+func NewResourceManager() *ResourceManager {
+	manager := &ResourceManager{}
+	manager.configs = make(map[string]*RuleSession)
+
+	return manager
+}
+
+func (m *ResourceManager) LoadResource(resConfig *resource.Config) error {
+
+	var rsConfig *RuleSession
+	err := json.Unmarshal(resConfig.Data, &rsConfig)
+	if err != nil {
+		return fmt.Errorf("error unmarshalling rulesession resource with id '%s', %s", resConfig.ID, err.Error())
+	}
+
+	m.configs[resConfig.ID] = rsConfig
+	return nil
+}
+
+func (m *ResourceManager) GetResource(id string) interface{} {
+	return m.configs[id]
+}
+
+func (m *ResourceManager) GetRuleSessionConfig(uri string) (*RuleSession, error) {
+
+	if strings.HasPrefix(uri, uriSchemeRes) {
+		return m.configs[uri[6:]], nil
+	}
+
+	return nil, errors.New("cannot find RuleSession: " + uri)
+}

--- a/config/registry.go
+++ b/config/registry.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"github.com/TIBCOSoftware/bego/common/model"
+	"errors"
+)
+
+var (
+	actionFunctions   = make(map[string]model.ActionFunction)
+	conditionEvaluators   = make(map[string]model.ConditionEvaluator)
+)
+
+// Register registers the specified ActionFunction
+func RegisterActionFunction(id string, actionFunction model.ActionFunction) error {
+
+	if actionFunction == nil {
+		return errors.New("cannot register 'nil' ActionFunction")
+	}
+
+	if _, dup := actionFunctions[id]; dup {
+		return errors.New("ActionFunction already registered: " + id)
+	}
+
+	actionFunctions[id] = actionFunction
+
+	return nil
+}
+
+// Get gets specified ActionFunction
+func GetActionFunction(id string) model.ActionFunction {
+	return actionFunctions[id]
+}
+
+// Register registers the specified ConditionEvaluator
+func RegisterConditionEvaluator(id string, conditionEvaluator model.ConditionEvaluator) error {
+
+	if conditionEvaluator == nil {
+		return errors.New("cannot register 'nil' ConditionEvaluator")
+	}
+
+	if _, dup := conditionEvaluators[id]; dup {
+		return errors.New("ConditionEvaluator already registered: " + id)
+	}
+
+	conditionEvaluators[id] = conditionEvaluator
+
+	return nil
+}
+
+// Get gets specified ConditionEvaluator
+func GetConditionEvaluator(id string) model.ConditionEvaluator {
+	return conditionEvaluators[id]
+}

--- a/examples/flogo/flogo.json
+++ b/examples/flogo/flogo.json
@@ -1,0 +1,115 @@
+{
+  "name": "bego",
+  "type": "flogo:app",
+  "version": "0.0.1",
+  "appModel": "1.0.0",
+
+  "triggers": [
+    {
+      "id": "receive_http_message",
+      "ref": "github.com/TIBCOSoftware/flogo-contrib/trigger/rest",
+      "name": "Receive HTTP Message",
+      "settings": {
+        "port": "7777"
+      },
+      "handlers": [
+        {
+          "name":"n1",
+          "settings": {
+            "method": "GET",
+            "path": "/test/:name"
+          },
+          "action": {
+            "id": "simple_rule",
+            "mappings": {
+              "input": [
+                {
+                  "mapTo": "values", "type": "assign", "value": "$.pathParams"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ],
+
+  "actions": [
+    {
+      "id": "simple_rule",
+      "ref": "github.com/TIBCOSoftware/bego/ruleaction",
+      "settings": {
+        "rulesession": "res://rulesession:simple"
+      },
+      "data" : {
+        "tds" :
+          [
+            {
+              "name": "n1",
+              "properties": [
+                {
+                  "name": "name",
+                  "type": "string",
+                  "pk-index": 0
+                }
+              ]
+            },
+            {
+              "name": "n2",
+              "properties": [
+                {
+                  "name": "name",
+                  "type": "string",
+                  "pk-index": 0
+                }
+              ]
+            }
+          ]
+      }
+    }
+  ],
+
+  "resources": [
+    {
+      "id": "rulesession:simple",
+      "data": {
+        "rules": [
+          {
+            "name": "n1.name == Bob",
+            "conditions": [
+              {
+                "name": "c1",
+                "identifiers": [
+                  "n1"
+                ],
+                "evaluator": "checkForBob"
+              }
+            ],
+            "actionFunction": "checkForBobAction"
+          },
+          {
+            "name": "n1.name == Bob && n1.name == n2.name",
+            "conditions": [
+              {
+                "name": "c1",
+                "identifiers": [
+                  "n1"
+                ],
+                "evaluator": "checkForBob"
+              },
+              {
+                "name": "c2",
+                "identifiers": [
+                  "n1",
+                  "n2"
+                ],
+                "evaluator": "checkSameNamesCondition"
+              }
+            ],
+            "actionFunction": "checkSameNamesAction"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/flogo/functions.go
+++ b/examples/flogo/functions.go
@@ -1,0 +1,64 @@
+package begofuncs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/TIBCOSoftware/bego/common/model"
+	"github.com/TIBCOSoftware/bego/config"
+)
+
+//add this sample file to your flogo project
+func init() {
+	config.RegisterActionFunction("checkForBobAction", checkForBobAction)
+	config.RegisterActionFunction("checkSameNamesAction", checkSameNamesAction)
+
+	config.RegisterConditionEvaluator("checkForBob", checkForBob)
+	config.RegisterConditionEvaluator("checkSameNamesCondition", checkSameNamesCondition)
+}
+
+func checkForBob(ruleName string, condName string, tuples map[model.TupleType]model.Tuple, ctx model.RuleContext) bool {
+	//This conditions filters on name="Bob"
+	t1 := tuples["n1"]
+	if t1 == nil {
+		fmt.Println("Should not get a nil tuple in FilterCondition! This is an error")
+		return false
+	}
+	name, _ := t1.GetString("name")
+	return name == "Bob"
+}
+
+func checkForBobAction(ctx context.Context, rs model.RuleSession, ruleName string, tuples map[model.TupleType]model.Tuple, ruleCtx model.RuleContext) {
+	fmt.Printf("Rule fired: [%s]\n", ruleName)
+	fmt.Printf("Context is [%s]\n", ruleCtx)
+	t1 := tuples["n1"]
+	if t1 == nil {
+		fmt.Println("Should not get nil tuples here in JoinCondition! This is an error")
+		return
+	}
+}
+
+func checkSameNamesCondition(ruleName string, condName string, tuples map[model.TupleType]model.Tuple, ctx model.RuleContext) bool {
+	t1 := tuples["n1"]
+	t2 := tuples["n2"]
+	if t1 == nil || t2 == nil {
+		fmt.Println("Should not get nil tuples here in JoinCondition! This is an error")
+		return false
+	}
+	name1, _ := t1.GetString("name")
+	name2, _ := t2.GetString("name")
+	return name1 == name2
+}
+
+func checkSameNamesAction(ctx context.Context, rs model.RuleSession, ruleName string, tuples map[model.TupleType]model.Tuple, ruleCtx model.RuleContext) {
+	fmt.Printf("Rule fired: [%s]\n", ruleName)
+	t1 := tuples["n1"]
+	t2 := tuples["n2"]
+	if t1 == nil || t2 == nil {
+		fmt.Println("Should not get nil tuples here in Action! This is an error")
+		return
+	}
+	name1, _ := t1.GetString("name")
+	name2, _ := t2.GetString("name")
+	fmt.Printf("n1.name = [%s], n2.name = [%s]\n", name1, name2)
+}

--- a/ruleaction/action.json
+++ b/ruleaction/action.json
@@ -6,5 +6,23 @@
   "title": "Rules Action",
   "description": "Simple Rules Action",
   "homepage": "https://github.com/TIBCOSoftware/bego/ruleaction",
-  "async": false
+  "async": false,
+
+  "settings": [
+    {
+      "name": "ruleSessionURI",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "tupleDescriptorFile",
+      "type": "string"
+    }
+  ],
+  "input":  [
+    {
+      "name": "data",
+      "type": "object"
+    }
+  ]
 }

--- a/ruleaction/action_old.go
+++ b/ruleaction/action_old.go
@@ -1,0 +1,395 @@
+package ruleaction
+
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"runtime/debug"
+	"io/ioutil"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/TIBCOSoftware/bego/common/model"
+	"github.com/TIBCOSoftware/bego/ruleapi"
+	"github.com/TIBCOSoftware/flogo-lib/core/action"
+	"github.com/TIBCOSoftware/flogo-lib/core/data"
+	"github.com/TIBCOSoftware/flogo-lib/core/trigger"
+	"github.com/TIBCOSoftware/flogo-lib/logger"
+)
+
+// Action ref to register the action factory
+const (
+	ActionRefOld = "github.com/TIBCOSoftware/bego/ruleaction_old"
+)
+
+// RuleActionOld wraps RuleSession
+type RuleActionOld struct {
+	rs model.RuleSession
+}
+
+// ActionFactory wrapper to register with the action
+type ActionFactoryOld struct {
+}
+
+//todo fix this
+var metadataOld = &action.Metadata{ID: ActionRefOld, Async: false}
+
+func init() {
+	action.RegisterFactory(ActionRefOld, &ActionFactoryOld{})
+}
+
+// Init implements action.Factory.Init
+func (ff *ActionFactoryOld) Init() error {
+	return nil
+}
+
+// ActionData maintains Tuple descriptor details
+type ActionDataOld struct {
+	Tds []model.TupleDescriptor
+}
+
+// New implements action.Factory.New
+func (ff *ActionFactoryOld) New(config *action.Config) (action.Action, error) {
+
+	ruleActionOld := &RuleActionOld{}
+
+	ruleActionOld.rs, _ = ruleapi.GetOrCreateRuleSession("flogosession")
+
+	actionData := ActionDataOld{}
+	actionData.Tds = []model.TupleDescriptor{}
+
+	err := json.Unmarshal(config.Data, &actionData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read rule action data '%s' error '%s'", config.Id, err.Error())
+	}
+	tdss, _ := json.Marshal(&actionData.Tds)
+	fmt.Printf("**ACTION DATA: [%s]\n**", string(tdss))
+
+	model.RegisterTupleDescriptors(string(tdss))
+
+	loadPkgRulesWithDeps(ruleActionOld.rs)
+
+	return ruleActionOld, nil
+}
+
+// Metadata get the Action's metadata
+func (a *RuleActionOld) Metadata() *action.Metadata {
+	return metadataOld
+}
+
+// IOMetadata get the Action's IO metadata
+func (a *RuleActionOld) IOMetadata() *data.IOMetadata {
+	return nil
+}
+
+// Run implements action.Action.Run
+func (a *RuleActionOld) Run(ctx context.Context, inputs map[string]*data.Attribute) (map[string]*data.Attribute, error) {
+
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Warnf("Unhandled Error executing rule action \n")
+
+			// todo: useful for debugging
+			logger.Debugf("StackTrace: %s", debug.Stack())
+		}
+
+	}()
+
+	h, _ok := trigger.HandlerFromContext(ctx)
+	if !_ok {
+		return nil, nil
+	}
+	//fmt.Printf("Received event from tuple source [%s]", h.Name)
+
+	tupleType := model.TupleType(h.Name)
+	queryParams := inputs["queryParams"].Value().(map[string]interface{})
+
+	tuple, _ := model.NewTuple(tupleType, queryParams) //n1 -> will be replaced by contextual information coming in the data
+	a.rs.Assert(ctx, tuple)
+	//fmt.Printf("[%s]\n", "b")
+	return nil, nil
+}
+
+//func loadRulesWithDeps(rs model.RuleSession) {
+//
+//	rule := ruleapi.NewRule("customer-event")
+//	rule.AddCondition("customer", []string{"customerevent.none"}, truecondition, nil) // check for name "Bob" in n1
+//	rule.SetAction(customerAction)
+//	rule.SetPriority(1)
+//	rs.AddRule(rule)
+//	fmt.Printf("Rule added: [%s]\n", rule.GetName())
+//
+//	rule2 := ruleapi.NewRule("debit-event")
+//	rule2.AddCondition("debitevent", []string{"debitevent.none"}, truecondition, nil)
+//	rule2.SetAction(debitEvent)
+//	rule2.SetPriority(2)
+//	rs.AddRule(rule2)
+//	fmt.Printf("Rule added: [%s]\n", rule2.GetName())
+//
+//	rule3 := ruleapi.NewRule("customer-debit")
+//	rule3.AddCondition("customerdebit", []string{"debitevent.name", "customerevent.name"}, customerdebitjoincondition, nil)
+//	rule3.SetAction(debitAction)
+//	rule3.SetPriority(3)
+//	rs.AddRule(rule3)
+//	fmt.Printf("Rule added: [%s]\n", rule3.GetName())
+//}
+
+func truecondition(ruleName string, condName string, tuples map[model.TupleType]model.Tuple, ctx model.RuleContext) bool {
+	return true
+}
+//func customerAction(ctx context.Context, rs model.RuleSession, ruleName string, tuples map[model.TupleType]model.Tuple, ruleCtx model.RuleContext) {
+//	tuple := tuples["customerevent"]
+//	if tuple == nil {
+//		fmt.Println("Should not get a nil tuple in FilterCondition! This is an error")
+//	} else {
+//		name, _ := tuple.GetString("name")
+//		fmt.Printf("Received a customer event with customer name [%s]\n", name)
+//	}
+//}
+//func debitEvent(ctx context.Context, rs model.RuleSession, ruleName string, tuples map[model.TupleType]model.Tuple, ruleCtx model.RuleContext) {
+//	tuple := tuples["debitevent"]
+//	if tuple == nil {
+//		fmt.Println("Should not get a nil tuple in FilterCondition! This is an error")
+//	} else {
+//		name, _ := tuple.GetString("name")
+//		amount, _ := tuple.GetString("debit")
+//
+//		fmt.Printf("Received a debit event for customer [%s], amount [%s]\n", name, amount)
+//	}
+//}
+//
+//func customerdebitjoincondition(ruleName string, condName string, tuples map[model.TupleType]model.Tuple, ctx model.RuleContext) bool {
+//
+//	customerTuple := tuples["customerevent"]
+//	debitTuple := tuples["debitevent"]
+//
+//	if customerTuple == nil || debitTuple == nil {
+//		fmt.Println("Should not get a nil tuple here! This is an error")
+//		return false
+//	}
+//	custName, _ := customerTuple.GetString("name")
+//	acctName, _ := debitTuple.GetString("name")
+//
+//	return custName == acctName
+//
+//}
+//
+//func debitAction(ctx context.Context, rs model.RuleSession, ruleName string, tuples map[model.TupleType]model.Tuple, ruleCtx model.RuleContext) {
+//	//fmt.Printf("Rule fired: [%s]\n", ruleName)
+//	customerTuple := tuples["customerevent"].(model.MutableTuple)
+//	debitTuple := tuples["debitevent"]
+//	dbt, _ := debitTuple.GetString("debit")
+//	debitAmt, _ := strconv.ParseFloat(dbt, 64)
+//	currBal, _ := customerTuple.GetDouble("balance")
+//	st, _ := customerTuple.GetString("status")
+//	if st == "active" {
+//		customerTuple.SetDouble(ctx, "balance", currBal-debitAmt)
+//	}
+//	nm, _ := customerTuple.GetString("name")
+//	newBal, _ := customerTuple.GetDouble("balance")
+//	fmt.Printf("Customer [%s], Balance [%f], Debit [%f], NewBalance [%f]\n", nm, currBal, debitAmt, newBal)
+//}
+
+func createRuleSessionAndRules() (model.RuleSession, error) {
+	rs, _ := ruleapi.GetOrCreateRuleSession("asession")
+
+	tupleDescFileAbsPath := getAbsPathForResource("src/github.com/TIBCOSoftware/bego/common/model/tupledescriptor.json")
+
+	dat, err := ioutil.ReadFile(tupleDescFileAbsPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = model.RegisterTupleDescriptors(string(dat))
+	if err != nil {
+		return nil, err
+	}
+	return rs, nil
+}
+
+func getAbsPathForResourceOld(resourcepath string) string {
+	GOPATH := os.Getenv("GOPATH")
+	fmt.Printf("path[%s]\n", GOPATH)
+	paths := strings.Split(GOPATH, ":")
+	for _, path := range paths {
+		fmt.Printf("path[%s]\n", path)
+		absPath := path + "/" + resourcepath
+		_, err := os.Stat(absPath)
+		if err == nil {
+			return absPath
+		}
+	}
+	return ""
+}
+
+func loadPkgRulesWithDeps(rs model.RuleSession) {
+
+	//handle a package event, create a package in the packageAction
+	rule := ruleapi.NewRule("packageevent")
+	rule.AddCondition("truecondition", []string{"packageevent.none"}, truecondition, nil)
+	rule.SetAction(packageeventAction)
+	rule.SetPriority(1)
+	rs.AddRule(rule)
+	fmt.Printf("Rule added: [%s]\n", rule.GetName())
+
+	//handle a package, print package details in the packageAction
+	rule1 := ruleapi.NewRule("package")
+	rule1.AddCondition("packageCondition", []string{"package.none"}, packageCondition, nil)
+	rule1.SetAction(packageAction)
+	rule1.SetPriority(2)
+	rs.AddRule(rule1)
+	fmt.Printf("Rule added: [%s]\n", rule1.GetName())
+
+	//handle a scan event, see if there is matching package if so, do necessary things such as set off a timer
+	//for the next destination, etc in the scaneventAction
+	rule2 := ruleapi.NewRule("scanevent")
+	rule2.AddCondition("scaneventCondition", []string{"package.packageid", "scanevent.packageid", "package.curr", "package.next"}, scaneventCondition, nil)
+	rule2.SetAction(scaneventAction)
+	rule2.SetPriority(2)
+	rs.AddRule(rule2)
+	fmt.Printf("Rule added: [%s]\n", rule2.GetName())
+
+	//handle a timeout event, triggered by scaneventAction, mark the package as delayed in scantimeoutAction
+	rule3 := ruleapi.NewRule("scantimeout")
+	rule3.AddCondition("scantimeoutCondition", []string{"package.packageid", "scantimeout.packageid"}, scantimeoutCondition, nil)
+	rule3.SetAction(scantimeoutAction)
+	rule3.SetPriority(1)
+	rs.AddRule(rule3)
+	fmt.Printf("Rule added: [%s]\n", rule3.GetName())
+
+	//notify when a package is marked as delayed, print as such in the packagedelayedAction
+	rule4 := ruleapi.NewRule("packagedelayed")
+	rule4.AddCondition("packageDelayedCheck", []string{"package.status"}, packageDelayedCheck, nil)
+	rule4.SetAction(packagedelayedAction)
+	rule4.SetPriority(1)
+	rs.AddRule(rule4)
+	fmt.Printf("Rule added: [%s]\n", rule4.GetName())
+}
+
+func packageeventAction(ctx context.Context, rs model.RuleSession, ruleName string, tuples map[model.TupleType]model.Tuple, ruleCtx model.RuleContext) {
+
+	pkgEvent := tuples["packageevent"]
+	pkgid, _ := pkgEvent.GetString("packageid")
+	fmt.Printf("Received a new package asserting package id[%s]\n", pkgid)
+
+	//assert a package
+	pkg, _ := model.NewTupleWithKeyValues(model.TupleType("package"), pkgid)
+	pkgID, _ := pkgEvent.GetString("packageid")
+	nxt, _ := pkgEvent.GetString("next")
+	pkg.SetString(ctx, "packageid", pkgID)
+	pkg.SetString(ctx, "curr", "start")
+	pkg.SetString(ctx, "next", nxt)
+	pkg.SetString(ctx, "status", "normal")
+
+	rs.Assert(ctx, pkg)
+}
+
+func scaneventCondition(ruleName string, condName string, tuples map[model.TupleType]model.Tuple, ctx model.RuleContext) bool {
+	scanevent := tuples["scanevent"]
+	pkg := tuples["package"]
+
+	if scanevent == nil || pkg == nil {
+		fmt.Println("Should not get a nil tuple here! This is an error")
+		return false
+	}
+	pkgID, _ := scanevent.GetString("packageid")
+	pkgID2, _ := pkg.GetString("packageid")
+	curr, _ := scanevent.GetString("curr")
+	nxt, _ := pkg.GetString("next")
+	return pkgID == pkgID2 && curr == nxt
+}
+
+func scaneventAction(ctx context.Context, rs model.RuleSession, ruleName string, tuples map[model.TupleType]model.Tuple, ruleCtx model.RuleContext) {
+	scanevent := tuples["scanevent"]
+
+	pkg := tuples["package"].(model.MutableTuple)
+	pkgid, _ := pkg.GetString("packageid")
+
+	scurr, _ := scanevent.GetString("curr")
+	snext, _ := scanevent.GetString("next")
+	fmt.Printf("Received a new scan event for package id[%s], current loc [%s], next loc [%s]\n", pkgid, scurr, snext)
+
+	if scanevent == nil || pkg == nil {
+		fmt.Println("Should not get a nil tuple here! This is an error")
+		return
+	}
+
+	etaS, _ := scanevent.GetString("eta")
+	eta, _ := strconv.Atoi(etaS)
+
+	scantmout, _ := model.NewTupleWithKeyValues(model.TupleType("scantimeout"), pkgid)
+	scantmout.SetString(ctx, "next", snext)
+
+	//cancel a previous timeout if set, since we got a scan event for the package's next destination
+	prevtmoutid := pkgid + scurr
+	rs.CancelScheduledAssert(ctx, prevtmoutid)
+
+	//start the timer only if this scanevent says that its not "done", so there are more destinations
+	if snext != "done" {
+		tmoutid := pkgid + snext
+		rs.ScheduleAssert(ctx, uint64(eta*1000), tmoutid, scantmout) //start the timer here
+	}
+	pkg.SetString(ctx, "curr", scurr)
+	pkg.SetString(ctx, "next", snext)
+
+}
+
+func scantimeoutCondition(ruleName string, condName string, tuples map[model.TupleType]model.Tuple, ctx model.RuleContext) bool {
+	scantimeout := tuples["scantimeout"]
+	pkg := tuples["package"]
+
+	if scantimeout == nil || pkg == nil {
+		fmt.Println("Should not get a nil tuple here! This is an error")
+		return false
+	}
+	pkgID, _ := scantimeout.GetString("packageid")
+	pkgID2, _ := pkg.GetString("packageid")
+	nxt, _ := scantimeout.GetString("next")
+	nxt2, _ := pkg.GetString("next")
+	return pkgID == pkgID2 &&
+		nxt == nxt2
+}
+
+func scantimeoutAction(ctx context.Context, rs model.RuleSession, ruleName string, tuples map[model.TupleType]model.Tuple, ruleCtx model.RuleContext) {
+
+	pkg := tuples["package"].(model.MutableTuple)
+
+	pkgid, _ := pkg.GetString("packageid")
+	pcurr, _ := pkg.GetString("curr")
+	pnext, _ := pkg.GetString("next")
+
+	fmt.Printf("Package id[%s] : Scan for dest [%s] did not arrive by ETA. Package currently at [%s]\n",
+		pkgid, pnext, pcurr)
+	pkg.SetString(ctx, "status", "delayed")
+}
+
+func packageCondition(ruleName string, condName string, tuples map[model.TupleType]model.Tuple, ctx model.RuleContext) bool {
+	pkg := tuples["package"]
+	isnew, _ := pkg.GetString("isnew")
+	return isnew == "true"
+}
+
+func packageAction(ctx context.Context, rs model.RuleSession, ruleName string, tuples map[model.TupleType]model.Tuple, ruleCtx model.RuleContext) {
+	pkg := tuples["package"].(model.MutableTuple)
+	pkgid, _ := pkg.GetString("packageid")
+
+	pcurr, _ := pkg.GetString("curr")
+	pnext, _ := pkg.GetString("next")
+	fmt.Printf("Received a new package id[%s], current loc [%s], next loc [%s]\n", pkgid, pcurr, pnext)
+	pkg.SetString(ctx, "isnew", "false")
+}
+
+func packageDelayedCheck(ruleName string, condName string, tuples map[model.TupleType]model.Tuple, ctx model.RuleContext) bool {
+	pkg := tuples["package"]
+	status, _ := pkg.GetString("status")
+	return status == "delayed"
+}
+
+func packagedelayedAction(ctx context.Context, rs model.RuleSession, ruleName string, tuples map[model.TupleType]model.Tuple, ruleCtx model.RuleContext) {
+	pkg := tuples["package"].(model.MutableTuple)
+	pkgid, _ := pkg.GetString("packageid")
+
+	fmt.Printf("Package is now delayed id[%s]\n", pkgid)
+}


### PR DESCRIPTION
I've add support for configuration via an object, which in turn is used for defining a "rulesession" resource in the flogo.json.  I've also updated the RuleAction accordingly.  I've also added an "examples" directory with a sample flogo.json and a functions registration file.

We should remove RuleActionOld.

