### PR TITLE
Remove multiple definitions for GetAbsPathForReference & FileToString

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -5,12 +5,13 @@ import (
 	"io"
 	"time"
 
-	"github.com/oklog/ulid"
-	"os"
 	"fmt"
-	"strings"
 	"io/ioutil"
 	"log"
+	"os"
+	"strings"
+
+	"github.com/oklog/ulid"
 )
 
 //unique id (26 chars)
@@ -41,12 +42,13 @@ func generateRandomBytes(n int) (io.Reader, error) {
 	return rand.Reader, nil
 }
 
+// GetAbsPathForResource gets the absolute resource path off $GOPATH
 func GetAbsPathForResource(resourcepath string) string {
 	GOPATH := os.Getenv("GOPATH")
-	fmt.Printf("path[%s]\n", GOPATH)
+	fmt.Printf("GOPATH - [%s]\n", GOPATH)
 	paths := strings.Split(GOPATH, ":")
 	for _, path := range paths {
-		fmt.Printf("path[%s]\n", path)
+		// fmt.Printf("path[%s]\n", path)
 		absPath := path + "/" + resourcepath
 		_, err := os.Stat(absPath)
 		if err == nil {
@@ -56,6 +58,7 @@ func GetAbsPathForResource(resourcepath string) string {
 	return ""
 }
 
+// FileToString reads file content to string
 func FileToString(fileName string) string {
 	dat, err := ioutil.ReadFile(fileName)
 	if err != nil {

--- a/examples/rulesapp/main.go
+++ b/examples/rulesapp/main.go
@@ -3,14 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"log"
-	"os"
-	"regexp"
-	"strings"
 
 	"github.com/project-flogo/rules/common/model"
 	"github.com/project-flogo/rules/ruleapi"
+	"github.com/vpatil-tibco/rules/common"
 )
 
 func main() {
@@ -18,8 +14,8 @@ func main() {
 	fmt.Println("** rulesapp: Example usage of the Rules module/API **")
 
 	//Load the tuple descriptor file (relative to GOPATH)
-	tupleDescAbsFileNm := getAbsPathForResource("src/github.com/project-flogo/rules/examples/rulesapp/rulesapp.json")
-	tupleDescriptor := fileToString(tupleDescAbsFileNm)
+	tupleDescAbsFileNm := common.GetAbsPathForResource("src/github.com/project-flogo/rules/examples/rulesapp/rulesapp.json")
+	tupleDescriptor := common.FileToString(tupleDescAbsFileNm)
 
 	fmt.Printf("Loaded tuple descriptor: \n%s\n", tupleDescriptor)
 	//First register the tuple descriptors
@@ -126,34 +122,4 @@ func checkSameNamesAction(ctx context.Context, rs model.RuleSession, ruleName st
 	name1, _ := t1.GetString("name")
 	name2, _ := t2.GetString("name")
 	fmt.Printf("n1.name = [%s], n2.name = [%s]\n", name1, name2)
-}
-
-func getAbsPathForResource(resourcepath string) string {
-	GOPATH := os.Getenv("GOPATH")
-	regex, err := regexp.Compile(":|;")
-	if err != nil {
-		return ""
-	}
-	paths := regex.Split(GOPATH, -1)
-	if os.PathListSeparator == ';' {
-		//windows
-		resourcepath = strings.Replace(resourcepath, "/", string(os.PathSeparator), -1)
-	}
-	for _, path := range paths {
-		absPath := path + string(os.PathSeparator) + resourcepath
-		_, err := os.Stat(absPath)
-		if err == nil {
-			return absPath
-		}
-	}
-	return ""
-}
-
-func fileToString(fileName string) string {
-	dat, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		log.Fatal(err)
-		return ""
-	}
-	return string(dat)
 }

--- a/ruleaction/action.go
+++ b/ruleaction/action.go
@@ -4,11 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"log"
-	"os"
 	"runtime/debug"
-	"strings"
 
 	"github.com/TIBCOSoftware/flogo-lib/app/resource"
 	"github.com/TIBCOSoftware/flogo-lib/core/action"
@@ -100,8 +96,8 @@ func (f *ActionFactory) New(cfg *action.Config) (action.Action, error) {
 
 	if settings.TupleDescFile != "" {
 		//Load the tuple descriptor file (relative to GOPATH)
-		tupleDescAbsFileNm := getAbsPathForResource(settings.TupleDescFile)
-		tupleDescriptor := fileToString(tupleDescAbsFileNm)
+		tupleDescAbsFileNm := common.GetAbsPathForResource(settings.TupleDescFile)
+		tupleDescriptor := common.FileToString(tupleDescAbsFileNm)
 
 		logger.Info("Loaded tuple descriptor: \n%s\n", tupleDescriptor)
 
@@ -226,31 +222,4 @@ func getSettings(config *action.Config) (*Settings, error) {
 	}
 
 	return settings, nil
-}
-
-//////////////
-// File Utils
-
-func getAbsPathForResource(resourcepath string) string {
-	GOPATH := os.Getenv("GOPATH")
-	fmt.Printf("path[%s]\n", GOPATH)
-	paths := strings.Split(GOPATH, ":")
-	for _, path := range paths {
-		fmt.Printf("path[%s]\n", path)
-		absPath := path + "/" + resourcepath
-		_, err := os.Stat(absPath)
-		if err == nil {
-			return absPath
-		}
-	}
-	return ""
-}
-
-func fileToString(fileName string) string {
-	dat, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		log.Fatal(err)
-		return ""
-	}
-	return string(dat)
 }

--- a/ruleaction/action_old.go
+++ b/ruleaction/action_old.go
@@ -6,15 +6,14 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 	"runtime/debug"
 	"strconv"
-	"strings"
 
 	"github.com/TIBCOSoftware/flogo-lib/core/action"
 	"github.com/TIBCOSoftware/flogo-lib/core/data"
 	"github.com/TIBCOSoftware/flogo-lib/core/trigger"
 	"github.com/TIBCOSoftware/flogo-lib/logger"
+	"github.com/project-flogo/rules/common"
 	"github.com/project-flogo/rules/common/model"
 	"github.com/project-flogo/rules/ruleapi"
 )
@@ -196,7 +195,7 @@ func truecondition(ruleName string, condName string, tuples map[model.TupleType]
 func createRuleSessionAndRules() (model.RuleSession, error) {
 	rs, _ := ruleapi.GetOrCreateRuleSession("asession")
 
-	tupleDescFileAbsPath := getAbsPathForResource("src/github.com/project-flogo/rules/common/model/tupledescriptor.json")
+	tupleDescFileAbsPath := common.GetAbsPathForResource("src/github.com/project-flogo/rules/common/model/tupledescriptor.json")
 
 	dat, err := ioutil.ReadFile(tupleDescFileAbsPath)
 	if err != nil {
@@ -207,21 +206,6 @@ func createRuleSessionAndRules() (model.RuleSession, error) {
 		return nil, err
 	}
 	return rs, nil
-}
-
-func getAbsPathForResourceOld(resourcepath string) string {
-	GOPATH := os.Getenv("GOPATH")
-	fmt.Printf("path[%s]\n", GOPATH)
-	paths := strings.Split(GOPATH, ":")
-	for _, path := range paths {
-		fmt.Printf("path[%s]\n", path)
-		absPath := path + "/" + resourcepath
-		_, err := os.Stat(absPath)
-		if err == nil {
-			return absPath
-		}
-	}
-	return ""
 }
 
 func loadPkgRulesWithDeps(rs model.RuleSession) {


### PR DESCRIPTION
Current behavior:
Multiple duplicate api definitions across multiple packages

What is the motivation / use case for changing the behavior?
Remove multiple definitions and instead use a single definition, so maintenance and changes going forward are central

Additional information you deem important (e.g. I need this tomorrow):