### PR TITLE
Add tuple get/set for object properties (Issue #19)

### DIFF
--- a/common/model/tests/tuple_test.go
+++ b/common/model/tests/tuple_test.go
@@ -1,0 +1,82 @@
+package test
+
+import (
+	"encoding/json"
+	"testing"
+	"bytes"
+
+    "github.com/project-flogo/rules/common/model"
+)
+
+func TestTupleObjectValue(t *testing.T) {
+
+	if err := model.RegisterTupleDescriptors(`
+        [
+          {
+            "name": "td1",
+            "properties": [
+              {
+                "name": "key",
+                "pk-index": 0,
+                "type": "string"
+              },
+              {
+                "name": "thing",
+                "type": "object"
+              }
+            ]
+		}]
+	`); err != nil {
+		t.Errorf("Failed to register tuple descriptor: %s", err)
+	}
+
+	tuple, err := model.NewTupleWithKeyValues("td1", "Bob")
+	if err != nil {
+		t.Errorf("Failed to create tuple: %s", err)
+	}
+
+	var thing map[string]interface{}
+	if err = json.Unmarshal([]byte(`{"foo": {"bar":"baz"}}`), &thing); err != nil {
+		t.Errorf("Failed to unmarshal object: %s", err);
+	}
+
+	if err = tuple.SetObject(nil, "thing", thing); err != nil {
+		t.Errorf("Failed to SetObject: %s", err)
+	}
+
+	thing2, err := tuple.GetObject("thing")
+	if err != nil {
+		t.Errorf("Failed to GetObject: %s", err)
+	}
+
+	thingJson, err := json.Marshal(thing)
+	thing2Json, err := json.Marshal(thing2)
+
+	if !bytes.Equal(thingJson, thing2Json) {
+		t.Errorf("Thing and thing2 are not equal: [%s] [%s]", thingJson, thing2Json);
+	}
+}
+
+func TestTupleObjectValueAsKey(t *testing.T) {
+
+	expect := "Property [key] is a mutable object and cannot be defined as a key for type [td1]"
+	err := model.RegisterTupleDescriptors(`
+        [
+          {
+            "name": "td1",
+            "properties": [
+              {
+                "name": "key",
+                "pk-index": 0,
+                "type": "object"
+              }
+            ]
+		}]
+	`)
+	if err == nil {
+		t.Errorf("Object was allowed as tuple key")
+	} else
+	if err.Error() != expect {
+		t.Errorf("Unexpected error registering td, wanted \"%s\" got \"%s\"", expect, err.Error())
+	}
+}

--- a/common/model/tuple.go
+++ b/common/model/tuple.go
@@ -21,6 +21,7 @@ type Tuple interface {
 	GetLong(name string) (val int64, err error)
 	GetDouble(name string) (val float64, err error)
 	GetBool(name string) (val bool, err error)
+	GetObject(name string) (val map[string]interface{}, err error)
 	//GetDateTime(name string) time.Time
 	GetKey() TupleKey
 }
@@ -33,6 +34,7 @@ type MutableTuple interface {
 	SetLong(ctx context.Context, name string, value int64) (err error)
 	SetDouble(ctx context.Context, name string, value float64) (err error)
 	SetBool(ctx context.Context, name string, value bool) (err error)
+	SetObject(ctx context.Context, name string, value map[string]interface{}) (err error)
 	//SetDatetime(ctx context.Context, name string, value time.Time) (err error)
 
 	//will try to coerce value to the named property's type
@@ -101,6 +103,17 @@ func (t *tupleImpl) GetString(name string) (val string, err error) {
 	return v, err
 }
 
+func (t *tupleImpl) GetObject(name string) (val map[string]interface{}, err error) {
+	err = t.chkProp(name)
+	if err != nil {
+		return nil, err
+	}
+	//try to coerce the tuple value to an object
+	v, err := coerce.ToObject(t.tuples[name])
+
+	return v, err
+}
+
 func (t *tupleImpl) GetInt(name string) (val int, err error) {
 	err = t.chkProp(name)
 	if err != nil {
@@ -157,6 +170,9 @@ func (t *tupleImpl) SetDouble(ctx context.Context, name string, value float64) (
 	return t.validateAndCallListener(ctx, name, value)
 }
 func (t *tupleImpl) SetBool(ctx context.Context, name string, value bool) (err error) {
+	return t.validateAndCallListener(ctx, name, value)
+}
+func (t *tupleImpl) SetObject(ctx context.Context, name string, value map[string]interface{}) (err error) {
 	return t.validateAndCallListener(ctx, name, value)
 }
 

--- a/common/model/tupledescriptor.go
+++ b/common/model/tupledescriptor.go
@@ -133,6 +133,10 @@ func (td *TupleDescriptor) UnmarshalJSON(b []byte) error {
 				tdp.KeyIndex = idx
 			}
 		}
+		if tdp.KeyIndex >= 0 && tdp.PropType == data.TypeObject {
+			return fmt.Errorf("Property [%s] is a mutable object and cannot be defined as a key for type [%s]",
+				idxProp[tdp.KeyIndex], nm)
+		}
 		td.Props = append(td.Props, tdp)
 	}
 


### PR DESCRIPTION
Currently tuples only support scalar properties. This patch adds basic support for objects (map[string]interface{}). Basic unit tests are included. This relates to https://github.com/project-flogo/rules/issues/19. 

We need this in a project to avoid considerable work in flattening existing request objects.

Since objects are mutable they are not allowed as tuple keys, this is prevented with a small change in tupledescriptor.UmarshalJSON. The other main limitation is that if an object is mutated in an action it will need to be set again with tuple.SetObject() in order to re-run the change listeners. The 'object' contents can be accessed via type assertions which is better than not having anything. Alternatively something like https://github.com/mitchellh/mapstructure can be used to get a real structure, or you can marshal->json->unmarshal->structure.

The resource file can be set up with the following to make it work with a REST trigger:

```
 {
    "settings": {
      "method": "POST",
      "path": "/test/n2"
    },
    "actions": [
      {
        "id": "simple_rule",
        "input": {
          "tupletype": "n2",
          "values": "=$.content"
        }
      }
    ]
 }
```

And the tuple descriptor:

```
"tds": [
  {
    "name": "n2",
    "properties": [
      {
        "name": "name",
        "pk-index": 0,
        "type": "string"
      },
      {
        "name": "thing",
        "type": "object"
      }
    ],
  }
]
```

POST content:

```
{
    "name": "Bob",
    "thing": {"foo":{"bar":"baz"}}
}
```